### PR TITLE
Issue1の解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Things you may want to cover:
 | ------------ | ---------- | ----------------- |
 | question     | text       | 
 | answer       | text       | 
-| display_date | integer    | null: false       |
-| display_year | integer    | null: false       |
+| display_date | date       | null: false       |
 | memory_level | integer    | null: false       |
 | repeat_count | integer    | null: false       |
 | user         | references | foreign_key: true |

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -51,7 +51,6 @@ class QuestionAnswersController < ApplicationController
   end
 
   def review
-    # where内の条件：display_yearが今年かつdisplay_dateが今日までの場合、またはdisplay_yearが今年よりも以前の場合
     @question_answers = @group.question_answers.where('display_date <= ?', Date.today).page(params[:page]).per(12)
   end
 

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -35,7 +35,7 @@ class QuestionAnswersController < ApplicationController
   end
 
   def update
-    if @question_answer.update(nested_form_params.except(:display_date, :display_year, :memory_level, :repeat_count))
+    if @question_answer.update(nested_form_params.except(:display_date, :memory_level, :repeat_count))
       redirect_to group_question_answer_path(@group, @question_answer)
     else
       render 'edit'

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -52,9 +52,7 @@ class QuestionAnswersController < ApplicationController
 
   def review
     # where内の条件：display_yearが今年かつdisplay_dateが今日までの場合、またはdisplay_yearが今年よりも以前の場合
-    @question_answers = @group.question_answers.where('display_year = ? AND display_date <= ?', Date.today.year, Date.today.yday)
-                              .or(@group.question_answers.where('display_year < ?', Date.today.year))
-                              .page(params[:page]).per(12)
+    @question_answers = @group.question_answers.where('display_date <= ?', Date.today).page(params[:page]).per(12)
   end
 
   private

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -69,6 +69,6 @@ class QuestionAnswersController < ApplicationController
     params.require(:question_answer).permit(:question, :answer,
                                             question_option_attributes: [:image, :font_size_id, :image_size_id, :id],
                                             answer_option_attributes: [:image, :font_size_id, :image_size_id, :id])
-          .merge(display_date: Date.today.yday, display_year: Date.today.year, memory_level: 0, repeat_count: 0, user_id: current_user.id, group_id: params[:group_id])
+          .merge(display_date: Date.today, memory_level: 0, repeat_count: 0, user_id: current_user.id, group_id: params[:group_id])
   end
 end

--- a/app/models/question_answer.rb
+++ b/app/models/question_answer.rb
@@ -2,8 +2,8 @@ class QuestionAnswer < ApplicationRecord
   validate :question_text_or_image_indispensable
   validate :answer_text_or_image_indispensable
   with_options presence: true do
+    validates :display_date
     with_options numericality: true do
-      validates :display_date
       validates :memory_level
       validates :repeat_count
     end

--- a/app/services/repetition_algorithm_service.rb
+++ b/app/services/repetition_algorithm_service.rb
@@ -58,27 +58,10 @@ class RepetitionAlgorithmService
     # easiness_factorの値を変化させる(memory_levelによってdifference_of_easiness_factorが決まる)
     @review_params[:easiness_factor] = @review_params[:easiness_factor].to_i + difference_of_easiness_factor
     limit_easiness_factor_range_130_to_250
-    next_display_date = Date.today.yday + @review_params[:interval].to_i
-    next_display_year = Date.today.year
-    if Date.new(Date.today.year).leap?
-      # 閏年の場合がtrueの場合の条件分岐(一年は366日)
-      if next_display_date > 366
-        # next_display_dateが366を超えてしまったら、自身から366を引き、next_display_yearに1を加算する
-        next_display_date -= 366
-        next_display_year += 1
-      end
-    else
-      # 閏年の場合がfalseの場合の条件分岐(一年は365日)
-      if next_display_date > 365
-        # next_display_dateが365を超えてしまったら、自身から365を引き、next_display_yearに1を加算する
-        next_display_date -= 365
-        next_display_year += 1
-      end
-    end
+    next_display_date = Date.today + @review_params[:interval].to_i
     ActiveRecord::Base.transaction do
       @repetition_algorithm.update!(interval: @review_params[:interval].round(4), easiness_factor: @review_params[:easiness_factor])
       @question_answer.update!(display_date: next_display_date,
-                               display_year: next_display_year,
                                memory_level: @review_params[:memory_level],
                                repeat_count: @review_params[:repeat_count].to_i + 1)
       Record.record_review_count(@question_answer.user_id, @review_params[:review_count].to_i)

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -17,8 +17,7 @@
       <% @groups.each do |group| %>
         <%= link_to review_group_question_answers_path(group), class: 'group-panel-link' do %>
           <%# ローカル変数countには、その日に復習できる問題の数が代入される %>
-          <%= render partial: 'group_panel', locals: { group: group, num: 0, count: group.question_answers.where('display_year = ? AND display_date <= ?', Date.today.year, Date.today.yday)
-                                                                                                          .or(group.question_answers.where('display_year < ?', Date.today.year)).count } %>
+          <%= render partial: 'group_panel', locals: { group: group, num: 0, count: group.question_answers.where('display_date <= ?', Date.today).count } %>
         <% end %>
         <%# formはcssでdisplay: none;されているので最初は非表示 %>
         <%= render partial: 'edit_form', locals: { group: group, num: 0 } %>

--- a/app/views/question_answers/show.html.erb
+++ b/app/views/question_answers/show.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'display_answer_content', locals: {question_answer: @question_answer} %>
   </div>
   <div>
-    次表示されるまでの日数：<%= @question_answer.display_date - Date.today.yday %>
+    次表示されるまでの日数：<%= (@question_answer.display_date - Date.today).to_i %>
   </div>
   <div>
     記憶度：<%= @question_answer.memory_level %>

--- a/db/migrate/20200818063951_create_question_answers.rb
+++ b/db/migrate/20200818063951_create_question_answers.rb
@@ -1,14 +1,13 @@
 class CreateQuestionAnswers < ActiveRecord::Migration[6.0]
   def change
     create_table :question_answers do |t|
-      t.text :question
-      t.text :answer
-      t.integer :display_date, null: false
-      t.integer :display_year, null: false
-      t.integer :memory_level, null: false
-      t.integer :repeat_count, null: false
-      t.references :user, foreign_key: true
-      t.references :group, foreign_key: true
+      t.text       :question
+      t.text       :answer
+      t.date       :display_date, null: false
+      t.integer    :memory_level, null: false
+      t.integer    :repeat_count, null: false
+      t.references :user,         foreign_key: true
+      t.references :group,        foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,8 +53,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_030407) do
   create_table "question_answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "question"
     t.text "answer"
-    t.integer "display_date", null: false
-    t.integer "display_year", null: false
+    t.date "display_date", null: false
     t.integer "memory_level", null: false
     t.integer "repeat_count", null: false
     t.bigint "user_id"


### PR DESCRIPTION
# What
- display_dateカラムとdisplay_yearカラムの統合
- 上記の変更に伴う各種修正

# Why
display_dateとdisplay_yearはカラムを分ける必要がなく、また、分けることで一部コードが複雑化してしまっていたため。