### PR TITLE
問題管理ページに各種管理機能を追加

### DIFF
--- a/app/assets/stylesheets/question_answer/index.css
+++ b/app/assets/stylesheets/question_answer/index.css
@@ -21,13 +21,17 @@
 .qa-index-item {
   position: relative;
   width: 580px;
-  height: 250px;
+  height: 265px;
   margin: 0 auto;
 }
 
 .qa-index-link-target {
   position: absolute;
   top: -50px;
+}
+
+.qa-index-notice {
+  color: #0000DD;
 }
 
 .qa-index-item__qa {
@@ -146,7 +150,7 @@ input[type="checkbox"]:checked ~ .qa-index-item__close {
 
   .qa-index-item {
     width: 290px;
-    height: 450px;
+    height: 465px;
     margin: 0 auto;
   }
 

--- a/app/assets/stylesheets/question_answer/index.css
+++ b/app/assets/stylesheets/question_answer/index.css
@@ -32,6 +32,7 @@
 
 .qa-index-notice {
   color: #0000DD;
+  font-size: 0.8rem;
 }
 
 .qa-index-item__qa {

--- a/app/assets/stylesheets/question_answer/index.css
+++ b/app/assets/stylesheets/question_answer/index.css
@@ -30,8 +30,8 @@
   top: -50px;
 }
 
-.qa-index-notice {
-  color: #0000DD;
+.qa-index-alert {
+  color: rgb(182, 48, 0);
   font-size: 0.8rem;
 }
 

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -64,8 +64,8 @@ class QuestionAnswersController < ApplicationController
   # 問題を投稿した時の状態にリセットするアクション
   def reset
     ActiveRecord::Base.transaction do
-      @question_answer.update(display_date: Date.today, memory_level: 0, repeat_count: 0)
-      @question_answer.repetition_algorithm.update(interval: 0, easiness_factor: 200)
+      @question_answer.update!(display_date: Date.today, memory_level: 0, repeat_count: 0)
+      @question_answer.repetition_algorithm.update!(interval: 0, easiness_factor: 200)
     end
     redirect_to url_of_specific_question_position_on_management_page, notice: '問題は初期状態にリセットされました'
   rescue StandardError => e

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -1,7 +1,7 @@
 class QuestionAnswersController < ApplicationController
   before_action :set_group
   before_action :set_question_answer, only: [:show, :edit, :update, :destroy, :reset]
-  before_action :set_session, only: :reset
+  before_action :set_session, only: [:destroy, :reset]
 
   def index
     @question_answers = @group.question_answers.page(params[:page]).per(10)
@@ -48,7 +48,7 @@ class QuestionAnswersController < ApplicationController
     if @question_answer.destroy
       redirect_back(fallback_location: root_path)
     else
-      reder 'show'
+      redirect_to url_of_specific_question_position_on_management_page, notice: '問題の削除に失敗しました'
     end
   end
 

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -37,7 +37,6 @@ class QuestionAnswersController < ApplicationController
 
   def update
     if @question_answer.update(nested_form_params.except(:display_date, :memory_level, :repeat_count))
-      # 問題管理ページの、編集を行った問題の場所にリダイレクト(ページネーションのページ数も考慮)
       redirect_to url_of_specific_question_position_on_management_page
     else
       render 'edit'

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -1,7 +1,6 @@
 class QuestionAnswersController < ApplicationController
   before_action :set_group
   before_action :set_question_answer, only: [:show, :edit, :update, :destroy, :reset, :remove]
-  before_action :set_session, only: [:destroy, :reset, :remove]
 
   def index
     @question_answers = @group.question_answers.page(params[:page]).per(10)
@@ -47,7 +46,8 @@ class QuestionAnswersController < ApplicationController
     if @question_answer.destroy
       redirect_back(fallback_location: root_path)
     else
-      redirect_to url_of_specific_question_position_on_management_page, notice: '問題の削除に失敗しました'
+      set_session
+      redirect_to url_of_specific_question_position_on_management_page, alert: '問題の削除に失敗しました'
     end
   end
 
@@ -67,17 +67,19 @@ class QuestionAnswersController < ApplicationController
       @question_answer.update!(display_date: Date.today, memory_level: 0, repeat_count: 0)
       @question_answer.repetition_algorithm.update!(interval: 0, easiness_factor: 200)
     end
-    redirect_to url_of_specific_question_position_on_management_page, notice: '問題は初期状態にリセットされました'
+    redirect_to url_of_specific_question_position_on_management_page
   rescue StandardError => e
-    redirect_to url_of_specific_question_position_on_management_page, notice: '問題のリセットに失敗しました'
+    set_session
+    redirect_to url_of_specific_question_position_on_management_page, alert: '問題のリセットに失敗しました'
   end
 
   # 問題を復習周期から外して、復習ページに表示されないようにするアクション
   def remove
     if @question_answer.update(display_date: Date.today + 100.year)
-      redirect_to url_of_specific_question_position_on_management_page, notice: '問題を復習周期から外しました'
+      redirect_to url_of_specific_question_position_on_management_page
     else
-      redirect_to url_of_specific_question_position_on_management_page, notice: '問題を復習周期から外すのに失敗しました'
+      set_session
+      redirect_to url_of_specific_question_position_on_management_page, alert: '問題を復習周期から外すのに失敗しました'
     end
   end
 

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -1,6 +1,7 @@
 class QuestionAnswersController < ApplicationController
   before_action :set_group
-  before_action :set_question_answer, only: [:show, :edit, :update, :destroy]
+  before_action :set_question_answer, only: [:show, :edit, :update, :destroy, :reset]
+  before_action :set_session, only: :reset
 
   def index
     @question_answers = @group.question_answers.page(params[:page]).per(10)
@@ -37,7 +38,7 @@ class QuestionAnswersController < ApplicationController
   def update
     if @question_answer.update(nested_form_params.except(:display_date, :memory_level, :repeat_count))
       # 問題管理ページの、編集を行った問題の場所にリダイレクト(ページネーションのページ数も考慮)
-      redirect_to "/groups/#{@group.id}/question_answers/?page=#{@group.question_answers.where('id<?', @question_answer.id).count / 10 + 1}#link-#{@question_answer.id}"
+      redirect_to url_of_specific_question_position_on_management_page
     else
       render 'edit'
     end
@@ -55,9 +56,21 @@ class QuestionAnswersController < ApplicationController
     @question_answers = @group.question_answers.where('display_date <= ?', Date.today).limit(10)
   end
 
+  # change_dateは挙動確認用。アプリリリース時には削除。
   def change_date
     @question_answers = @group.question_answers.where('display_date <= ?', params[:date]).limit(10)
     @date = params[:date]
+  end
+
+  # 問題を投稿した時の状態にリセットするアクション
+  def reset
+    ActiveRecord::Base.transaction do
+      @question_answer.update(display_date: Date.today, memory_level: 0, repeat_count: 0)
+      @question_answer.repetition_algorithm.update(interval: 0, easiness_factor: 200)
+    end
+    redirect_to url_of_specific_question_position_on_management_page, notice: '問題は初期状態にリセットされました'
+  rescue StandardError => e
+    redirect_to url_of_specific_question_position_on_management_page, notice: '問題のリセットに失敗しました'
   end
 
   private
@@ -70,10 +83,20 @@ class QuestionAnswersController < ApplicationController
     @question_answer = QuestionAnswer.find(params[:id])
   end
 
+  def set_session
+    session[:qa_id] = @question_answer.id
+  end
+
   def nested_form_params
     params.require(:question_answer).permit(:question, :answer,
                                             question_option_attributes: [:image, :font_size_id, :image_size_id, :id],
                                             answer_option_attributes: [:image, :font_size_id, :image_size_id, :id])
           .merge(display_date: Date.today, memory_level: 0, repeat_count: 0, user_id: current_user.id, group_id: params[:group_id])
+  end
+
+  # 問題管理ページの、特定の問題の位置に遷移するためのurl
+  def url_of_specific_question_position_on_management_page
+    # ?page=#{@group.question_answers.where('id<?', @question_answer.id).count / 10 + 1} この部分は特定の問題が、ページネーションで分割したどのページに存在するかを考慮して遷移するための記述。
+    "/groups/#{@group.id}/question_answers/?page=#{@group.question_answers.where('id<?', @question_answer.id).count / 10 + 1}#link-#{@question_answer.id}"
   end
 end

--- a/app/controllers/question_answers_controller.rb
+++ b/app/controllers/question_answers_controller.rb
@@ -1,7 +1,7 @@
 class QuestionAnswersController < ApplicationController
   before_action :set_group
-  before_action :set_question_answer, only: [:show, :edit, :update, :destroy, :reset]
-  before_action :set_session, only: [:destroy, :reset]
+  before_action :set_question_answer, only: [:show, :edit, :update, :destroy, :reset, :remove]
+  before_action :set_session, only: [:destroy, :reset, :remove]
 
   def index
     @question_answers = @group.question_answers.page(params[:page]).per(10)
@@ -71,6 +71,15 @@ class QuestionAnswersController < ApplicationController
     redirect_to url_of_specific_question_position_on_management_page, notice: '問題は初期状態にリセットされました'
   rescue StandardError => e
     redirect_to url_of_specific_question_position_on_management_page, notice: '問題のリセットに失敗しました'
+  end
+
+  # 問題を復習周期から外して、復習ページに表示されないようにするアクション
+  def remove
+    if @question_answer.update(display_date: Date.today + 100.year)
+      redirect_to url_of_specific_question_position_on_management_page, notice: '問題を復習周期から外しました'
+    else
+      redirect_to url_of_specific_question_position_on_management_page, notice: '問題を復習周期から外すのに失敗しました'
+    end
   end
 
   private

--- a/app/helpers/question_answers_helper.rb
+++ b/app/helpers/question_answers_helper.rb
@@ -2,11 +2,11 @@ module QuestionAnswersHelper
   # 復習までの日数を、dateに応じて条件分岐して値を返すメソッド
   def display_date_until_review(date)
     if date >= 0 && date <= 100
-      "#{date}"
+      date.to_s
     elsif date < 0
-      "0"
+      '0'
     else
-      "--"
+      '--'
     end
   end
 end

--- a/app/helpers/question_answers_helper.rb
+++ b/app/helpers/question_answers_helper.rb
@@ -1,2 +1,12 @@
 module QuestionAnswersHelper
+  # 復習までの日数を、dateに応じて条件分岐して値を返すメソッド
+  def display_date_until_review(date)
+    if date >= 0 && date <= 100
+      "#{date}"
+    elsif date < 0
+      "0"
+    else
+      "--"
+    end
+  end
 end

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -9,7 +9,9 @@
       <div class="qa-index-item" >
         <%# 復習ページから遷移してくる際に正常に位置を調整するためのターゲット。画面上に非表示。 %>
         <div class="qa-index-link-target" id=link-<%=question_answer.id%>></div>
-        <% if session[:qa_id] == question_answer.id %>
+        <%# resetやremoveアクションなどを実行すると、操作を行ったレコードのidがsession[:qa_id]に保存される。そのidがquestion_answer.idと等しい場合、noticeを表示 %>
+        <% if question_answer.id == session[:qa_id] %>
+          <%# セッションの中身をリセット %>
           <% session[:qa_id] = nil %> 
           <p class="qa-index-notice"><%= notice %></p>
         <% end %>

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -10,7 +10,7 @@
         <%# 復習ページから遷移してくる際に正常に位置を調整するためのターゲット。画面上に非表示。 %>
         <div class="qa-index-link-target" id=link-<%=question_answer.id%>></div>
         <% if session[:qa_id] == question_answer.id %>
-          <% session[:qa_id] = nil %>
+          <% session[:qa_id] = nil %> 
           <p class="qa-index-notice"><%= notice %></p>
         <% end %>
         <%# 問題と解答を表示 %>
@@ -25,10 +25,12 @@
             復習までの日数：
             <span>
               <%# 復習までの日数がマイナスになる場合は0と表記する %>
-              <% if (question_answer.display_date - Date.today).to_i >= 0 %>
+              <% if (question_answer.display_date - Date.today).to_i >= 0 && (question_answer.display_date - Date.today).to_i <= 100 %>
                 <%= (question_answer.display_date - Date.today).to_i %>
-              <% else %>
+              <% elsif (question_answer.display_date - Date.today).to_i < 0 %>
                 0
+              <% else %>
+               --
               <% end %>
             </span>
             記憶度：<span><%= question_answer.memory_level %></span>
@@ -44,7 +46,7 @@
           <ul class="qa-index-item__management-list">
             <li><%= link_to '問題編集', edit_group_question_answer_path(@group, question_answer) %></li>
             <li><%= link_to '初期状態にリセット', reset_group_question_answer_path(@group, question_answer), method: :patch %></li>
-            <li>復習周期から外す</li>
+            <li><%= link_to '復習周期から外す', remove_group_question_answer_path(@group, question_answer), method: :patch %></li>
             <li><%= link_to '削除', group_question_answer_path(@group, question_answer), method: :delete %></li>
           </ul>
           <%# //以上のlabelとul要素は初期状態では非表示。上の縦3点リーダーの画像をクリックすることで表示される %>

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -9,11 +9,11 @@
       <div class="qa-index-item" >
         <%# 復習ページから遷移してくる際に正常に位置を調整するためのターゲット。画面上に非表示。 %>
         <div class="qa-index-link-target" id=link-<%=question_answer.id%>></div>
-        <%# resetやremoveアクションなどを実行すると、操作を行ったレコードのidがsession[:qa_id]に保存される。そのidがquestion_answer.idと等しい場合、noticeを表示 %>
+        <%# resetやremove,destroyアクションが失敗すると、操作対象のレコードのidがsession[:qa_id]に保存される。そのidと同じidを持つ問題が表示されている場所で、alertを出す %>
         <% if question_answer.id == session[:qa_id] %>
           <%# セッションの中身をリセット %>
           <% session[:qa_id] = nil %> 
-          <p class="qa-index-notice"><%= notice %></p>
+          <p class="qa-index-alert"><%= alert %></p>
         <% end %>
         <%# 問題と解答を表示 %>
         <div class="qa-index-item__qa">

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -22,17 +22,7 @@
         <%# 問題と解答の下に位置するコンテンツを表示 %>
         <div class="qa-index-item__description">
           <div class="qa-index-item__record">
-            復習までの日数：
-            <span>
-              <%# 復習までの日数がマイナスになる場合は0と表記する %>
-              <% if (question_answer.display_date - Date.today).to_i >= 0 && (question_answer.display_date - Date.today).to_i <= 100 %>
-                <%= (question_answer.display_date - Date.today).to_i %>
-              <% elsif (question_answer.display_date - Date.today).to_i < 0 %>
-                0
-              <% else %>
-               --
-              <% end %>
-            </span>
+            復習までの日数：<span><%= display_date_until_review((question_answer.display_date - Date.today).to_i) %></span>
             記憶度：<span><%= question_answer.memory_level %></span>
             復習回数：<span><%= question_answer.repeat_count %></span>
           </div>

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -9,6 +9,10 @@
       <div class="qa-index-item" >
         <%# 復習ページから遷移してくる際に正常に位置を調整するためのターゲット。画面上に非表示。 %>
         <div class="qa-index-link-target" id=link-<%=question_answer.id%>></div>
+        <% if session[:qa_id] == question_answer.id %>
+          <% session[:qa_id] = nil %>
+          <p class="qa-index-notice"><%= notice %></p>
+        <% end %>
         <%# 問題と解答を表示 %>
         <div class="qa-index-item__qa">
           <%= render partial: 'display_question_content', locals: {question_answer: question_answer} %>
@@ -39,8 +43,8 @@
           <%# 以下のリストは縦3点リーダーアイコンを押さない限り非表示 %>
           <ul class="qa-index-item__management-list">
             <li><%= link_to '問題編集', edit_group_question_answer_path(@group, question_answer) %></li>
+            <li><%= link_to '初期状態にリセット', reset_group_question_answer_path(@group, question_answer), method: :patch %></li>
             <li>復習周期から外す</li>
-            <li>初期状態にリセット</li>
             <li><%= link_to '削除', group_question_answer_path(@group, question_answer), method: :delete %></li>
           </ul>
           <%# //以上のlabelとul要素は初期状態では非表示。上の縦3点リーダーの画像をクリックすることで表示される %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :create, :update, :destroy] do
     resources :question_answers do
       collection do
-        get 'review', 'change_date'
+        get 'review', 'change_date' # change_dateは挙動確認用。アプリリリース時には削除
+      end
+      member do
+        patch 'reset', 'remove'
       end
     end
   end


### PR DESCRIPTION
# What
- 問題を投稿した時点と同じ、初期状態に戻す機能を実装
- 問題を復習周期から外し、復習ページに表示させないようにする機能を実装

# Why
問題を初期状態に戻す機能 - 理解が不十分な問題を再度重点的に復習できるようにするため
問題を復習周期から外す機能 - 十分理解して復習の必要はないが、削除はしたくない場合があると感じたため
