### PR TITLE
Issueの解消]問題編集時に画像を削除する機能を追加

### DIFF
--- a/app/assets/stylesheets/question_answer/index.css
+++ b/app/assets/stylesheets/question_answer/index.css
@@ -181,12 +181,12 @@
   text-decoration: none;
 }
 
-input[type="checkbox"] {
+.qa-index-item__checkbox {
   position: absolute;
   left: -100vw;
 }
 
-input[type="checkbox"]:checked ~ .qa-index-item__management-list{
+.qa-index-item__checkbox:checked ~ .qa-index-item__management-list{
   display: block;
   position: absolute;
   right: 0px;
@@ -197,7 +197,7 @@ input[type="checkbox"]:checked ~ .qa-index-item__management-list{
   z-index: 2;
 }
 
-input[type="checkbox"]:checked ~ .qa-index-item__close {
+.qa-index-item__checkbox:checked ~ .qa-index-item__close {
   display: block;
 }
 

--- a/app/assets/stylesheets/question_answer/qa-form.css
+++ b/app/assets/stylesheets/question_answer/qa-form.css
@@ -106,11 +106,13 @@
 .answer-preview__img-destroy {
   display: block;
   width: 50px;
-  height: 25px;
-  line-height: 25px;
+  height: 23px;
+  line-height: 19px;
+  border: 2px solid #000;
+  font-size: 0.9rem;
+  color: #000;
   text-align: center;
   cursor: pointer;
-  outline: 1px solid #000;
 }
 
 .question-pulldown,

--- a/app/assets/stylesheets/question_answer/qa-form.css
+++ b/app/assets/stylesheets/question_answer/qa-form.css
@@ -49,7 +49,8 @@
   cursor: pointer;
 }
 
-.qa-form__checkbox {
+#qa-form__question-checkbox,
+#qa-form__answer-checkbox {
   position: absolute;
   left: -100vw;
 }
@@ -97,6 +98,19 @@
 .img-preview-answer {
   width: 200px;
   height: auto;
+  vertical-align: bottom;
+}
+
+
+.question-preview__img-destroy,
+.answer-preview__img-destroy {
+  display: block;
+  width: 50px;
+  height: 25px;
+  line-height: 25px;
+  text-align: center;
+  cursor: pointer;
+  outline: 1px solid #000;
 }
 
 .question-pulldown,

--- a/app/assets/stylesheets/question_answer/qa-form.css
+++ b/app/assets/stylesheets/question_answer/qa-form.css
@@ -105,10 +105,12 @@
 .question-preview__img-destroy,
 .answer-preview__img-destroy {
   display: block;
-  width: 50px;
+  width: 90px;
   height: 23px;
-  line-height: 19px;
-  border: 2px solid #000;
+  line-height: 21px;
+  border: 1px solid #808080;
+  border-radius: 3px;
+  background-color: rgb(239, 239, 239);
   font-size: 0.9rem;
   color: #000;
   text-align: center;

--- a/app/assets/stylesheets/question_answer/qa-form.css
+++ b/app/assets/stylesheets/question_answer/qa-form.css
@@ -49,6 +49,11 @@
   cursor: pointer;
 }
 
+.qa-form__checkbox {
+  position: absolute;
+  left: -100vw;
+}
+
 .hidden {
   display: none;
 }

--- a/app/assets/stylesheets/question_answer/qa-form.css
+++ b/app/assets/stylesheets/question_answer/qa-form.css
@@ -51,6 +51,8 @@
 
 #qa-form__question-checkbox,
 #qa-form__answer-checkbox {
+  /* フォームの入力欄をtabで移動する際にcheckboxが割り込んでくるので、display: none;でcheckboxの方にはtab移動しないようにする */
+  display: none;
   position: absolute;
   left: -100vw;
 }

--- a/app/assets/stylesheets/question_answer/review.css
+++ b/app/assets/stylesheets/question_answer/review.css
@@ -89,11 +89,16 @@
   z-index: 2;
 }
 
-input[type="checkbox"]:checked ~ .memory-level-detail {
+.review-option__checkbox {
+  position: absolute;
+  left: -100vw;
+}
+
+.review-option__checkbox:checked ~ .memory-level-detail {
   display: block;
 }
 
-input[type="checkbox"]:checked ~ .review-option__close {
+.review-option__checkbox:checked ~ .review-option__close {
   display: block;
 }
 

--- a/app/javascript/change_font_or_image_size_by_pulldown.js
+++ b/app/javascript/change_font_or_image_size_by_pulldown.js
@@ -7,17 +7,8 @@ window.addEventListener("load", (e) => {
                                             action ===  "edit" ||
                                             action === "update")){
 
-    // プルダウンのoption要素の中でselectedされている要素を返り値として返す関数式
-    const getSelectedOptionInPulldown = (questionOrAnswer, fontOrImage) => {
-      const pulldownElement = document.getElementById(`question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id`)
-      // 現在選択されているブルダウンの項目が、上から何番目の項目なのかを取得
-      const value = pulldownElement.value
-      // プルダウン内のoption要素を全て取得
-      const pulldownOptions = document.querySelectorAll(`#question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id option`);
-      // 現在選択されているプルダウンの項目の要素(<option>)を取得
-      const selectedOption = pulldownOptions[value - 1];
-      return selectedOption
-    }
+    // モジュールを読み込むことで、プルダウンでselectedされているoption要素を返す関数式を、変数に代入
+    const getSelectedOptionInPulldown = require('./module_get_selected_option.js')
 
     // プルダウンのselectedされているoption要素の値を用いて、プレビューエリアのフォントサイズを変更する関数式
     const changeFontSize = (questionOrAnswer) => {

--- a/app/javascript/module_get_selected_option.js
+++ b/app/javascript/module_get_selected_option.js
@@ -1,0 +1,13 @@
+// プルダウンのoption要素の中でselectedされている要素を返り値として返す関数式
+const getSelectedOptionInPulldown = (questionOrAnswer, fontOrImage) => {
+  const pulldownElement = document.getElementById(`question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id`)
+  // 現在選択されているブルダウンの項目が、上から何番目の項目なのかを取得
+  const value = pulldownElement.value
+  // プルダウン内のoption要素を全て取得
+  const pulldownOptions = document.querySelectorAll(`#question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id option`);
+  // 現在選択されているプルダウンの項目の要素(<option>)を取得
+  const selectedOption = pulldownOptions[value - 1];
+  return selectedOption
+}
+
+module.exports = getSelectedOptionInPulldown;

--- a/app/javascript/preview_if_text_or_image_input.js
+++ b/app/javascript/preview_if_text_or_image_input.js
@@ -6,6 +6,9 @@ window.addEventListener("load", (e) => {
                                             action === "create" ||
                                             action ===  "edit" ||
                                             action === "update")){
+    
+    // モジュールを読み込むことで、プルダウンでselectedされているoption要素を返す関数式を、変数に代入
+    const getSelectedOptionInPulldown = require('./module_get_selected_option.js')
 
     imagePreview()
     textareaPreview()
@@ -18,15 +21,10 @@ window.addEventListener("load", (e) => {
         hiddenFileFields[i].addEventListener('change', (e) => {
           // 画像を取り込むと、その画像をプレビュー表示する関数式
           const questionOrAnswerImagePreview = (questionOrAnswer) => {
-            const imageContent = document.querySelector(`.img-preview-${questionOrAnswer}`);
-            let imageElement = ""
-            if (imageContent){
-              if(imageContent.hasAttribute("style")){
-                // もし画像が存在し、さらにstyle属性を持つならば、styleの属性値を変数imageElementに代入
-                imageElement = imageContent.getAttribute("style")
-              }
-              // 画像がブラウザ上に存在する場合のみ、すでに存在している画像を削除する
-              imageContent.remove();
+            const previewImage = document.getElementById(`${questionOrAnswer}-preview__img`);
+            // previewImageに子要素が存在する場合、全て削除する(画像と削除ボタンの2つが存在する場合がある)
+            while (previewImage.firstChild){
+              previewImage.removeChild(previewImage.firstChild);
             };
 
             // 以下5行で、取り込んだ画像を表示する<img>要素作成
@@ -35,12 +33,10 @@ window.addEventListener("load", (e) => {
             const blobImage = document.createElement('img')
             blobImage.setAttribute('src', blob)
             blobImage.setAttribute("class", `img-preview-${questionOrAnswer}`)
-            // もしimageElementの値が存在するなら、上記で作成した<img>要素にstyle属性とその属性値としてimageElementを追加
-            if (imageElement){
-              blobImage.setAttribute("style", `${imageElement}`)
-            }
+            // img要素に、プルダウンで選択されている値を考慮したwidthを設定
+            const selectedOption = getSelectedOptionInPulldown(questionOrAnswer, "image")
+            blobImage.setAttribute("style", `width: ${Math.floor(200 * selectedOption.innerHTML)}px;`)
 
-            const previewImage = document.getElementById(`${questionOrAnswer}-preview__img`)
             previewImage.appendChild(blobImage)
           }
 

--- a/app/javascript/preview_when_page_loaded.js
+++ b/app/javascript/preview_when_page_loaded.js
@@ -37,12 +37,22 @@ window.addEventListener("load", (e) => {
         image.setAttribute("style", `width: ${Math.floor(200 * selectedOption.innerHTML)}px;`)
         const insertImage = document.getElementById(`${questionOrAnswer}-preview__img`)
         insertImage.appendChild(image)
-        // checkboxと紐付けるlabel要素を生成
+        // checkboxと紐付けるために、label要素を生成して変数destroyに代入
         const destroy = document.createElement("label")
         destroy.innerText = '削除'
         destroy.setAttribute("class", `${questionOrAnswer}-preview__img-destroy`)
         destroy.setAttribute("for", `qa-form__${questionOrAnswer}-checkbox`)
         insertImage.insertAdjacentElement('beforeend', destroy)
+        // destroyに、クリックするとボタンの見た目を変更するイベントを追加
+        destroy.addEventListener("click", (e) => {
+          if (destroy.getAttribute("data-clicked") == null){
+            destroy.setAttribute("data-clicked", "true")
+            destroy.setAttribute("style", "background-color: #282c2f; color: #fff;")
+          } else {
+            destroy.removeAttribute("data-clicked")
+            destroy.removeAttribute("style")
+          }
+        })
       }
     }
 

--- a/app/javascript/preview_when_page_loaded.js
+++ b/app/javascript/preview_when_page_loaded.js
@@ -7,17 +7,8 @@ window.addEventListener("load", (e) => {
                                             action === "update" ||
                                             action === "create")){
 
-    // プルダウンのoption要素の中でselectedされている要素を返り値として返す関数式
-    const getSelectedOptionInPulldown = (questionOrAnswer, fontOrImage) => {
-      const pulldownElement = document.getElementById(`question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id`)
-      // 現在選択されているブルダウンの項目が、上から何番目の項目なのかを取得
-      const value = pulldownElement.value
-      // プルダウン内のoption要素を全て取得
-      const pulldownOptions = document.querySelectorAll(`#question_answer_${questionOrAnswer}_option_attributes_${fontOrImage}_size_id option`);
-      // 現在選択されているプルダウンの項目の要素(<option>)を取得
-      const selectedOption = pulldownOptions[value - 1];
-      return selectedOption
-    }
+    // モジュールを読み込むことで、プルダウンでselectedされているoption要素を返す関数式を、変数に代入
+    const getSelectedOptionInPulldown = require('./module_get_selected_option.js')
 
     // テキストエリアに入力された値を取得し、フォントサイズのプルダウンで設定された倍率を適用した上で、プレビュー表示する関数式
     const setText = (questionOrAnswer) => {

--- a/app/javascript/preview_when_page_loaded.js
+++ b/app/javascript/preview_when_page_loaded.js
@@ -39,7 +39,7 @@ window.addEventListener("load", (e) => {
         insertImage.appendChild(image)
         // checkboxと紐付けるために、label要素を生成して変数destroyに代入
         const destroy = document.createElement("label")
-        destroy.innerText = '削除'
+        destroy.innerText = '画像を削除'
         destroy.setAttribute("class", `${questionOrAnswer}-preview__img-destroy`)
         destroy.setAttribute("for", `qa-form__${questionOrAnswer}-checkbox`)
         insertImage.insertAdjacentElement('beforeend', destroy)

--- a/app/javascript/preview_when_page_loaded.js
+++ b/app/javascript/preview_when_page_loaded.js
@@ -37,6 +37,12 @@ window.addEventListener("load", (e) => {
         image.setAttribute("style", `width: ${Math.floor(200 * selectedOption.innerHTML)}px;`)
         const insertImage = document.getElementById(`${questionOrAnswer}-preview__img`)
         insertImage.appendChild(image)
+        // checkboxと紐付けるlabel要素を生成
+        const destroy = document.createElement("label")
+        destroy.innerText = '削除'
+        destroy.setAttribute("class", `${questionOrAnswer}-preview__img-destroy`)
+        destroy.setAttribute("for", `qa-form__${questionOrAnswer}-checkbox`)
+        insertImage.insertAdjacentElement('beforeend', destroy)
       }
     }
 

--- a/app/views/question_answers/_qa_form_input.html.erb
+++ b/app/views/question_answers/_qa_form_input.html.erb
@@ -5,6 +5,7 @@
     <%= f.fields_for :question_option do |qo| %>
       <%= qo.label :image, "画像", class:"qa-form__image-btn" %>
       <%= qo.file_field :image, class:"hidden" %>
+      <%= qo.check_box :_destroy, class:"qa-form__checkbox" %>
     <% end %>
   </div>
   <div class="qa-form__input-answer-wrap">
@@ -12,6 +13,7 @@
     <%= f.fields_for :answer_option do |ao| %>
       <%= ao.label :image, "画像", class:"qa-form__image-btn" %>
       <%= ao.file_field :image, class:"hidden" %>
+      <%= ao.check_box :_destroy, class:"qa-form__checkbox" %>
     <% end %>
   </div>
 </div>

--- a/app/views/question_answers/_qa_form_input.html.erb
+++ b/app/views/question_answers/_qa_form_input.html.erb
@@ -5,7 +5,7 @@
     <%= f.fields_for :question_option do |qo| %>
       <%= qo.label :image, "画像", class:"qa-form__image-btn" %>
       <%= qo.file_field :image, class:"hidden" %>
-      <%= qo.check_box :_destroy, class:"qa-form__checkbox" %>
+      <%= qo.check_box :_destroy, id:"qa-form__question-checkbox" %>
     <% end %>
   </div>
   <div class="qa-form__input-answer-wrap">
@@ -13,7 +13,7 @@
     <%= f.fields_for :answer_option do |ao| %>
       <%= ao.label :image, "画像", class:"qa-form__image-btn" %>
       <%= ao.file_field :image, class:"hidden" %>
-      <%= ao.check_box :_destroy, class:"qa-form__checkbox" %>
+      <%= ao.check_box :_destroy, id:"qa-form__answer-checkbox" %>
     <% end %>
   </div>
 </div>

--- a/app/views/question_answers/change_date.html.erb
+++ b/app/views/question_answers/change_date.html.erb
@@ -30,7 +30,7 @@
           <div class="review-option__memory-level-description">
             <div class="review-option__memory-level-text">記憶度</div>
             <%# このチェックボックスは画面上に表示されない。下のlabel要素2つと紐づいている %>
-            <input type="checkbox" id="review-option__check-<%=i%>">
+            <input type="checkbox" id="review-option__check-<%=i%>" class="review-option__checkbox">
             <label for="review-option__check-<%=i%>" class="review-option__question"><%= image_tag 'review_question.png', class: "review-option__question-img" %></label>
             <%# 以下のlabel要素は?アイコンを押さない限り非表示 %>
             <label for="review-option__check-<%=i%>" class="review-option__close"></label>

--- a/app/views/question_answers/index.html.erb
+++ b/app/views/question_answers/index.html.erb
@@ -63,7 +63,7 @@
             復習回数：<span><%= question_answer.repeat_count %></span>
           </div>
           <%# このチェックボックスは画面上には表示されない。下のlabel要素2つと紐づいている。 %>
-          <input type="checkbox" id="qa-index__check-<%=i%>">
+          <input type="checkbox" id="qa-index__check-<%=i%>" class="qa-index-item__checkbox">
           <label for="qa-index__check-<%=i%>"><%= image_tag 'vertical_three_point_reader.png', class: 'qa-index-item__img-three-point' %></label>
           <div class="img-three-point-supplement-text">管理</div>
           <%# 以下のlabel要素は縦3点リーダーアイコンを押さない限り非表示 %>

--- a/app/views/question_answers/review.html.erb
+++ b/app/views/question_answers/review.html.erb
@@ -35,7 +35,7 @@
           <div class="review-option__memory-level-description">
             <div class="review-option__memory-level-text">記憶度</div>
             <%# このチェックボックスは画面上に表示されない。下のlabel要素2つと紐づいている %>
-            <input type="checkbox" id="review-option__check-<%=i%>">
+            <input type="checkbox" id="review-option__check-<%=i%>" class="review-option__checkbox">
             <label for="review-option__check-<%=i%>" class="review-option__question"><%= image_tag 'review_question.png', class: "review-option__question-img" %></label>
             <%# 以下のlabel要素は?アイコンを押さない限り非表示 %>
             <label for="review-option__check-<%=i%>" class="review-option__close"></label>

--- a/spec/system/question_answers_spec.rb
+++ b/spec/system/question_answers_spec.rb
@@ -424,6 +424,41 @@ RSpec.describe '問題編集機能', type: :system do
       expect(page).to have_css('.display-question-content__image')
       expect(page).to have_css('.display-answer-content__image')
     end
+
+    it '編集時に画像を削除できること' do
+      question_answer = FactoryBot.create(:question_answer, user_id: @user.id, group_id: @group.id)
+      # サインインする
+      login(@user)
+      # トップページに遷移していることを確認する
+      expect(current_path).to eq root_path
+      # 問題管理ページへのリンクをクリックする
+      find('.group-panel.js-2').click
+      # 問題管理ページへ遷移していることを確認する
+      expect(current_path).to eq group_question_answers_path(@group)
+      # 問題エリアと解答エリアに、保存した画像が存在することを確認する
+      expect(page).to have_css('.display-question-content__image')
+      expect(page).to have_css('.display-answer-content__image')
+      # 縦三点リーダーのアイコンをクリックする
+      find('.qa-index-item__img-three-point').click
+      # 問題編集のリンクをクリックする
+      all('.qa-index-item__management-list a')[0].click
+      # 問題編集ページへ遷移していることを確認する
+      expect(current_path).to eq edit_group_question_answer_path(@group, question_answer)
+      # 問題と解答のプレビューエリアに「画像を削除」ボタンが存在することを確認する
+      expect(page).to have_css(".question-preview__img-destroy")
+      expect(page).to have_css(".answer-preview__img-destroy")
+      # 「画像を削除」ボタンをクリックする(問題と解答両方)
+      find(".question-preview__img-destroy").click
+      find(".answer-preview__img-destroy").click
+      # 編集ボタンをクリックしてフォームを送信する
+      find('input[name="commit"]').click
+      # 問題管理ページの編集した問題の位置に遷移していることを確認する(URIのpathとqueryとfragmentが一致しているか確認)
+      uri = URI.parse(current_url)
+      expect("#{uri.path}?#{uri.query}##{uri.fragment}").to eq "/groups/#{@group.id}/question_answers/?page=#{@group.question_answers.where('id<?', question_answer.id).count / 10 + 1}#link-#{question_answer.id}"
+      # 問題エリアと解答エリアに表示されていた画像が削除されていることを確認する
+      expect(page).to have_no_css('.display-question-content__image')
+      expect(page).to have_no_css('.display-answer-content__image')
+    end
   end
 
   context '問題編集に失敗した時' do

--- a/spec/system/question_answers_spec.rb
+++ b/spec/system/question_answers_spec.rb
@@ -445,11 +445,11 @@ RSpec.describe '問題編集機能', type: :system do
       # 問題編集ページへ遷移していることを確認する
       expect(current_path).to eq edit_group_question_answer_path(@group, question_answer)
       # 問題と解答のプレビューエリアに「画像を削除」ボタンが存在することを確認する
-      expect(page).to have_css(".question-preview__img-destroy")
-      expect(page).to have_css(".answer-preview__img-destroy")
+      expect(page).to have_css('.question-preview__img-destroy')
+      expect(page).to have_css('.answer-preview__img-destroy')
       # 「画像を削除」ボタンをクリックする(問題と解答両方)
-      find(".question-preview__img-destroy").click
-      find(".answer-preview__img-destroy").click
+      find('.question-preview__img-destroy').click
+      find('.answer-preview__img-destroy').click
       # 編集ボタンをクリックしてフォームを送信する
       find('input[name="commit"]').click
       # 問題管理ページの編集した問題の位置に遷移していることを確認する(URIのpathとqueryとfragmentが一致しているか確認)


### PR DESCRIPTION
# What
- 問題編集時に画像を削除する機能を追加
- 複数のjsファイルで利用していた関数をモジュール化して、重複コード解消
- 問題編集時の画像削除機能の結合テストコードを記述

# Why
- 問題に添付した画像のみを削除できるようにするため
- 重複コードを解消して保守性を維持するため